### PR TITLE
config : CI/CD 파이프라인 구축 (github actions)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,74 @@
+name : CD/CD
+
+on:
+  push:
+    branches:
+      - main
+    pull_request:
+      branches:
+        - main
+
+  jobs:
+    build-and-test-spring:
+      name: Build and Test Spring Boot
+      runs-on: ubuntu-24.04.1
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Set up Java
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'amazon-corretto'
+            java-version: '17'
+            cache: 'gradle'
+
+        - name: Build Spring Boot application
+          run: |
+            chmod +x gradlew
+            ./gradlew clean build -x test
+
+        - name: Upload JAR artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: spring-boot-jar
+            path: target/*.jar
+
+    build-and-push-docker-image:
+      name: Build and Push Docker Image
+      needs: build-and-test-spring # Spring Boot 빌드 Job이 성공해야 실행
+      runs-on: ubuntu-24.04.1
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' # main 브랜치 푸시에만 실행
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Download JAR artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: spring-boot-app
+            path: . # 현재 디렉토리로 다운로드
+
+        - name: Log in to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKER_HUB_USERNAME }} # GitHub Secrets에 저장
+            password: ${{ secrets.DOCKER_HUB_TOKEN }} # GitHub Secrets에 저장 (Personal Access Token 권장)
+
+        - name: Get current date for image tag
+          id: date
+          run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            push: true
+            tags: |
+              your-dockerhub-username/your-spring-app-name:latest
+              your-dockerhub-username/your-spring-app-name:${{ steps.date.outputs.date }}
+            # build-args: | # Dockerfile에 ARG가 있다면 여기에 추가
+            #   JAR_FILE=your-spring-app.jar # JAR 파일명 지정 (Dockerfile과 일치)
+            #   APP_PORT=8080

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,9 +37,9 @@ jobs:
 
   build-and-push-docker-image:
     name: Build and Push Docker Image
-    needs: build-and-test-spring # Spring Boot 빌드 Job이 성공해야 실행
+    needs: build-and-test-spring
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/config/github-actions' # main 브랜치 푸시에만 실행
+    if: github.event_name == 'push' && github.ref == 'refs/heads/config/github-actions'
 
     steps:
       - name: Checkout code
@@ -49,13 +49,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: spring-boot-jar
-          path: . # 현재 디렉토리로 다운로드
+          path: .
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }} # GitHub Secrets에 저장
-          password: ${{ secrets.DOCKER_HUB_TOKEN }} # GitHub Secrets에 저장 (Personal Access Token 권장)
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Get current date for image tag
         id: date

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name : CD/CD
+name : CI/CD
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-test-spring:
     name: Build and Test Spring Boot
-    runs-on: ubuntu-24.04.1
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -20,14 +20,14 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'amazon-corretto'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
       - name: Build Spring Boot application
         run: |
           chmod +x gradlew
-          ./gradlew clean build -x test
+          ./gradlew build -x test
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,7 +3,7 @@ name : CD/CD
 on:
   push:
     branches:
-      - main
+      - config/github-actions
     pull_request:
       branches:
         - main
@@ -34,41 +34,3 @@ on:
           with:
             name: spring-boot-jar
             path: target/*.jar
-
-    build-and-push-docker-image:
-      name: Build and Push Docker Image
-      needs: build-and-test-spring # Spring Boot 빌드 Job이 성공해야 실행
-      runs-on: ubuntu-24.04.1
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' # main 브랜치 푸시에만 실행
-
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-
-        - name: Download JAR artifact
-          uses: actions/download-artifact@v4
-          with:
-            name: spring-boot-app
-            path: . # 현재 디렉토리로 다운로드
-
-        - name: Log in to Docker Hub
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.DOCKER_HUB_USERNAME }} # GitHub Secrets에 저장
-            password: ${{ secrets.DOCKER_HUB_TOKEN }} # GitHub Secrets에 저장 (Personal Access Token 권장)
-
-        - name: Get current date for image tag
-          id: date
-          run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
-
-        - name: Build and push Docker image
-          uses: docker/build-push-action@v5
-          with:
-            context: .
-            push: true
-            tags: |
-              your-dockerhub-username/your-spring-app-name:latest
-              your-dockerhub-username/your-spring-app-name:${{ steps.date.outputs.date }}
-            # build-args: | # Dockerfile에 ARG가 있다면 여기에 추가
-            #   JAR_FILE=your-spring-app.jar # JAR 파일명 지정 (Dockerfile과 일치)
-            #   APP_PORT=8080

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,3 +69,41 @@ jobs:
           tags: |
             ongst52/giantmall:latest
             ongst52/giantmall:${{ steps.date.outputs.date }}
+            
+
+  deploy-to-server:
+    name: Deploy to Remote Server
+    needs: build-and-push-docker-image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/config/github-actions'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: SSH to remote server and deploy
+        uses: appleboy/ssh-action@v1.0.1 # SSH 접속을 위한 GitHub Action
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }} # 개인 키 (PEM 형식)
+          script: |
+            echo "Connecting to remote server and deploying..."
+            # 서버의 프로젝트 경로로 이동
+            cd /path/to/your/project/on/server
+            
+            # Docker Compose 파일이 최신인지 확인 (Git pull 또는 scp로 복사)
+            git pull origin main # 또는 scp로 docker-compose.yml 파일 전송
+            
+            # Docker 이미지 업데이트 및 서비스 재시작
+            # 이 부분은 docker-compose.yml 내용에 따라 달라질 수 있습니다.
+            # docker-compose.yml 파일 내에 이미지 태그를 latest로 사용하는 경우:
+            docker-compose pull # 최신 이미지 다운로드
+            docker-compose down # 기존 서비스 중단
+            docker-compose up -d --build # --build를 사용하면 Dockerfile 변경 사항도 반영
+            
+            # 또는 특정 태그를 사용하고 docker-compose.yml을 동적으로 업데이트해야 하는 경우:
+            # sed -i "s|your-dockerhub-username/your-spring-app-name:.*|your-dockerhub-username/your-spring-app-name:${{ steps.build-and-push-docker-image.outputs.date }}|" docker-compose.yml
+            # docker-compose up -d
+            
+            echo "Deployment completed successfully!"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-test-spring:
     name: Build and Test Spring Boot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.0.1
 
     steps:
       - name: Checkout code
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'amazon-corretto'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,7 +3,7 @@ name : CI/CD
 on:
   push:
     branches:
-      - config/github-actions
+      - main
     pull_request:
       branches:
         - main
@@ -39,7 +39,7 @@ jobs:
     name: Build and Push Docker Image
     needs: build-and-test-spring
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/config/github-actions'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
@@ -75,7 +75,7 @@ jobs:
     name: Deploy to Remote Server
     needs: build-and-push-docker-image
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/config/github-actions'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
@@ -93,7 +93,7 @@ jobs:
             cd ./giantmall/GIANT-MALL-BE/
             
             git fetch origin
-            git reset --hard origin/config/github-actions
+            git reset --hard origin/main
             
             sudo docker-compose pull
             sudo docker-compose down

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -82,28 +82,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: SSH to remote server and deploy
-        uses: appleboy/ssh-action@v1.0.1 # SSH 접속을 위한 GitHub Action
+        uses: appleboy/ssh-action@v1.0.1
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }} # 개인 키 (PEM 형식)
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             echo "Connecting to remote server and deploying..."
-            # 서버의 프로젝트 경로로 이동
-            cd /path/to/your/project/on/server
+            cd /home/GA/giantmall/GIANT-MALL-BE/
             
-            # Docker Compose 파일이 최신인지 확인 (Git pull 또는 scp로 복사)
-            git pull origin main # 또는 scp로 docker-compose.yml 파일 전송
+            git pull origin main
             
-            # Docker 이미지 업데이트 및 서비스 재시작
-            # 이 부분은 docker-compose.yml 내용에 따라 달라질 수 있습니다.
-            # docker-compose.yml 파일 내에 이미지 태그를 latest로 사용하는 경우:
-            docker-compose pull # 최신 이미지 다운로드
-            docker-compose down # 기존 서비스 중단
-            docker-compose up -d --build # --build를 사용하면 Dockerfile 변경 사항도 반영
-            
-            # 또는 특정 태그를 사용하고 docker-compose.yml을 동적으로 업데이트해야 하는 경우:
-            # sed -i "s|your-dockerhub-username/your-spring-app-name:.*|your-dockerhub-username/your-spring-app-name:${{ steps.build-and-push-docker-image.outputs.date }}|" docker-compose.yml
-            # docker-compose up -d
+            docker-compose pull
+            docker-compose down
+            docker-compose up -d
             
             echo "Deployment completed successfully!"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,7 +89,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             echo "Connecting to remote server and deploying..."
-            cd /home/GA/giantmall/GIANT-MALL-BE/
+            cd ./giantmall/GIANT-MALL-BE/
             
             git pull origin config/github-actions
             

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -92,6 +92,8 @@ jobs:
             echo "Connecting to remote server and deploying..."
             cd ./giantmall/GIANT-MALL-BE/
             
+            git fetch origin
+            git switch -c config/github-actions
             git pull origin config/github-actions
             
             docker-compose pull

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build and Push Docker Image
     needs: build-and-test-spring # Spring Boot 빌드 Job이 성공해야 실행
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' # main 브랜치 푸시에만 실행
+    if: github.event_name == 'push' && github.ref == 'refs/heads/config/github-actions' # main 브랜치 푸시에만 실행
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
+          passphrase: ${{ secrets.SSH_PASSPHRASE }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             echo "Connecting to remote server and deploying..."

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,7 +93,6 @@ jobs:
             cd ./giantmall/GIANT-MALL-BE/
             
             git fetch origin
-            git switch config/github-actions
             git reset --hard origin/config/github-actions
             
             sudo docker-compose pull

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Download JAR artifact
         uses: actions/download-artifact@v4
         with:
-          name: spring-boot-app
+          name: spring-boot-jar
           path: . # 현재 디렉토리로 다운로드
 
       - name: Log in to Docker Hub

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,4 +97,4 @@ jobs:
             docker-compose down
             docker-compose up -d
             
-            echo "Deployment completed successfully!"
+            echo "Deployment completed successfully"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,5 +67,5 @@ jobs:
           context: .
           push: true
           tags: |
-            your-dockerhub-username/your-spring-app-name:latest
-            your-dockerhub-username/your-spring-app-name:${{ steps.date.outputs.date }}
+            ongst52/giantmall:latest
+            ongst52/giantmall:${{ steps.date.outputs.date }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: spring-boot-jar
-          path: target/*.jar
+          path: build/libs/*.jar
 
   build-and-push-docker-image:
     name: Build and Push Docker Image

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,10 +94,10 @@ jobs:
             
             git fetch origin
             git switch config/github-actions
-            git pull origin config/github-actions
+            git reset --hard origin/config/github-actions
             
-            docker-compose pull
-            docker-compose down
-            docker-compose up -d
+            sudo docker-compose pull
+            sudo docker-compose down
+            sudo docker-compose up -d
             
             echo "Deployment completed successfully"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,29 +8,29 @@ on:
       branches:
         - main
 
-  jobs:
-    build-and-test-spring:
-      name: Build and Test Spring Boot
-      runs-on: ubuntu-24.04.1
+jobs:
+  build-and-test-spring:
+    name: Build and Test Spring Boot
+    runs-on: ubuntu-24.04.1
 
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-        - name: Set up Java
-          uses: actions/setup-java@v4
-          with:
-            distribution: 'amazon-corretto'
-            java-version: '17'
-            cache: 'gradle'
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'amazon-corretto'
+          java-version: '17'
+          cache: 'gradle'
 
-        - name: Build Spring Boot application
-          run: |
-            chmod +x gradlew
-            ./gradlew clean build -x test
+      - name: Build Spring Boot application
+        run: |
+          chmod +x gradlew
+          ./gradlew clean build -x test
 
-        - name: Upload JAR artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: spring-boot-jar
-            path: target/*.jar
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spring-boot-jar
+          path: target/*.jar

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'amazon-corretto'
           java-version: '17'
           cache: 'gradle'
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-test-spring:
     name: Build and Test Spring Boot
-    runs-on: ubuntu-24.0.1
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -27,10 +27,45 @@ jobs:
       - name: Build Spring Boot application
         run: |
           chmod +x gradlew
-          ./gradlew build -x test
+          ./gradlew clean build -x test
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4
         with:
           name: spring-boot-jar
           path: target/*.jar
+
+  build-and-push-docker-image:
+    name: Build and Push Docker Image
+    needs: build-and-test-spring # Spring Boot 빌드 Job이 성공해야 실행
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' # main 브랜치 푸시에만 실행
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download JAR artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spring-boot-app
+          path: . # 현재 디렉토리로 다운로드
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }} # GitHub Secrets에 저장
+          password: ${{ secrets.DOCKER_HUB_TOKEN }} # GitHub Secrets에 저장 (Personal Access Token 권장)
+
+      - name: Get current date for image tag
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            your-dockerhub-username/your-spring-app-name:latest
+            your-dockerhub-username/your-spring-app-name:${{ steps.date.outputs.date }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    pull_request:
-      branches:
-        - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-and-test-spring:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Get current date for image tag
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+        run:  |
+          echo "date=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,7 +93,7 @@ jobs:
             cd ./giantmall/GIANT-MALL-BE/
             
             git fetch origin
-            git switch -c config/github-actions
+            git switch config/github-actions
             git pull origin config/github-actions
             
             docker-compose pull

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,7 +91,7 @@ jobs:
             echo "Connecting to remote server and deploying..."
             cd /home/GA/giantmall/GIANT-MALL-BE/
             
-            git pull origin main
+            git pull origin config/github-actions
             
             docker-compose pull
             docker-compose down


### PR DESCRIPTION
closes #10

## 변경 사항
github actions를 통해 main 브랜치에 push 이벤트 일어날 때 
도커 이미지 빌드 -> 도커 허브 푸쉬 -> git reset -> docker compose pull & up
단계의 파이프라인 구축

---

### 이슈

1. 인스턴스 SSH 재연결 시 .ssh/authorized_key 파일이 삭제되는 일회성 버그 발생
원인은 찾지 못했으나 재발하지 않아 보류

2. deploy-to-server 스텝의 쉘 스크립트에서 sudo 명령어 추가할 시 sudo visudo 로 권한 부여 후 사용해야 함

3. .env 파일 통일해야함
